### PR TITLE
New filter (alfa) to cut the higher ack_train_disp

### DIFF
--- a/net/ipv4/tcp_wave.c
+++ b/net/ipv4/tcp_wave.c
@@ -115,7 +115,9 @@ struct wavetcp {
 	u32 max_rtt;
 	/* Stability factor */
 	u8 stab_factor;
-
+	/* Previous ack_train_disp Value */
+	u32 previous_ack_train_disp;
+	
 	/* The memory cache for saving the burst sizes */
 	struct kmem_cache *cache;
 	/* The burst history */
@@ -162,6 +164,7 @@ static void wavetcp_init(struct sock *sk)
 	ca->max_rtt = 0;
 	ca->stab_factor = 0;
 	ca->avg_ack_train_disp = 0;
+	ca->previous_ack_train_disp = 0;
 
 	ca->history = kmalloc(sizeof(struct wavetcp_burst_hist), GFP_KERNEL);
 
@@ -483,7 +486,20 @@ static void wavetcp_round_terminated(struct sock *sk, const struct rate_sample *
 		    tcp_time_stamp);
 		return;
 	}
-
+	else if (ack_train_disp > ca->previous_ack_train_disp && ca->previous_ack_train_disp != 0) 
+ 	{
+		unsigned long alfa;
+  		unsigned long left;
+  		unsigned long right;
+  			alfa = (delta_rtt * AVG_UNIT) / (beta_ms * 1000);
+				left = ((AVG_UNIT - alfa) * ca->previous_ack_train_disp) / AVG_UNIT;
+				right = (alfa * ack_train_disp) / AVG_UNIT;
+		DBG("%u [wavetcp_round_terminated] use previous ack_train_disp %u us, alfa %lu to filter a received ack_train_disp %u us\n",
+		    tcp_time_stamp, ca->previous_ack_train_disp, alfa, ack_train_disp);
+				ack_train_disp = left + right;
+	}
+		ca->previous_ack_train_disp = ack_train_disp;
+	
 	DBG("%u [wavetcp_round_terminated] ack_train_disp %u us, drtt %llu, sf %u\n",
 	    tcp_time_stamp, ack_train_disp, delta_rtt, ca->stab_factor);
 


### PR DESCRIPTION
1 - At begging, accept the first ack_train_disp value, if it is higher than 0.
2 - Any ack train dispersion value measured later on is compared to the previous one (previous_ack_train_disp);
   - if it is smaller, use it for statistics and update the previous_ack_train_disp value.
   - if it is higher, apply the "alfa weighted filter" to cut the value, where [the finally used ack_train_disp= (1-alpha) * previous_ack_train_disp + alpha * the measured ack train dispersion]
  - alpha= dRTT/beta